### PR TITLE
[Programmers] feat : 2개 이하로 다른 비트 문제 풀이 추가

### DIFF
--- a/SUPINKIM/BOJ/knapsack.js
+++ b/SUPINKIM/BOJ/knapsack.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().split('\n');
+const [n, k] = input[0].split(' ').map((x) => +x);
+let dp = Array.from(new Array(n + 1), () => new Array(k + 1).fill(0));
+
+for (let i = 1; i <= n; i++) {
+  const [w, v] = input[i]
+    .trim()
+    .split(' ')
+    .map((x) => +x);
+  for (let j = 0; j <= k; j++) {
+    if (w > j) {
+      dp[i][j] = dp[i - 1][j];
+    } else {
+      dp[i][j] = Math.max(dp[i - 1][j], dp[i - 1][j - w] + v);
+    }
+  }
+}
+
+console.log(dp[n][k]);

--- a/SUPINKIM/Programmers/transformBinary.js
+++ b/SUPINKIM/Programmers/transformBinary.js
@@ -1,0 +1,23 @@
+function solution(numbers) {
+  const result = numbers.map((x) => {
+    const binary = x.toString(2).split('');
+    if (x % 2 === 0) {
+      binary[binary.length - 1] = '1';
+    } else {
+      let index = null;
+      if (x.toString(2).lastIndexOf('01') !== -1) {
+        index = x.toString(2).lastIndexOf('01');
+        binary[index] = '1';
+        binary[index + 1] = '0';
+      } else if (x.toString(2).lastIndexOf('10') !== -1) {
+        index = x.toString(2).lastIndexOf('10');
+        binary[index + 1] = '1';
+      } else {
+        binary.push('1');
+        binary[1] = '0';
+      }
+    }
+    return parseInt(binary.join(''), 2);
+  });
+  return result;
+}

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -32,6 +32,8 @@
 
 - [경주로 건설(code)](./Programmers/track.js) | [문제 보기](https://programmers.co.kr/learn/courses/30/lessons/67259)
 
+- [2개 이하로 다른 비트(code)](./Programmers/tranformBinary.js) | [문제 보기](https://programmers.co.kr/learn/courses/30/lessons/77885)
+
 ## BOJ(백준 온라인 저지)
 
 - [1167.트리의 지름(code)](./BOJ/treeDiameter.js) | [문제 보기](https://www.acmicpc.net/problem/1167)

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -53,3 +53,5 @@
 - [2250. 트리의 높이와 너비(code)](./BOJ/treeHeightWidth.js) | [문제 보기](https://www.acmicpc.net/problem/2250)
 
 - [15651. N과 M(3)(code)](./BOJ/n_m3.js) | [문제 보기](https://www.acmicpc.net/problem/15651)
+
+- [12865. 평범한 배낭(code)](./BOJ/knapsack.js) | [문제 보기](https://www.acmicpc.net/problem/12865)


### PR DESCRIPTION
<작업 내용>
 1. 프로그래머스 level2. 2개 이하로 다른 비트 문제 풀이 추가 
    > https://programmers.co.kr/learn/courses/30/lessons/77885
    > 반복문 돌려 각 자리수마다 체크하는 방식 시간 초과. 2진법 원리 적용 필요

2. BOJ 백준 온라인 저지 12865. 평범한 배낭 문제풀이 추가 
    > 다이내믹 프로그래밍(DP) 문제
    > 처음에 완전 탐색으로 풀었다가 시간 초과 발생. 완전 탐색으로 풀 경우 오히려 풀이가 더 복잡해짐.
    > 현재 배낭에 넣고 싶은 무게가 비교 중인 무게보다 적은 경우, (이전까지의 최대 가치 + 현재 가치 값) vs 이전까지의 최대값 비교가 핵심
    > https://www.acmicpc.net/problem/12865