### PR TITLE
[BOJ] feat : 트리 순회 문제풀이 추가

### DIFF
--- a/SUPINKIM/BOJ/hideandshow.js
+++ b/SUPINKIM/BOJ/hideandshow.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+let [n, k] = fs
+  .readFileSync('/dev/stdin')
+  .toString()
+  .trim()
+  .split(' ')
+  .map((x) => +x);
+
+const visited = new Array(100001).fill(false);
+
+function move(start, path) {
+  const queue = [[start, path]];
+  let index = 0;
+  while (index < queue.length) {
+    const [position, route] = queue[index];
+    if (position !== k) {
+      [position - 1, position + 1, 2 * position].forEach((next) => {
+        if (!visited[next] && next >= 0 && next <= 100000) {
+          const nextPath = route + `${next} `;
+          queue.push([next, nextPath]);
+          visited[next] = true;
+        }
+      });
+    } else {
+      return route;
+    }
+    index++;
+  }
+}
+
+function init() {
+  const result = move(n, `${n} `);
+  console.log(result.trim().split(' ').length - 1);
+  console.log(result.trim());
+}
+
+init();

--- a/SUPINKIM/BOJ/paper.js
+++ b/SUPINKIM/BOJ/paper.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().split('\n');
+
+const [n, m] = input[0]
+  .trim()
+  .split(' ')
+  .map((x) => +x);
+const map = [];
+const check = [];
+const EXPONENT = n * m - 1;
+let max = -Infinity;
+
+function createNums(bit) {
+  const bitArr = bit.split('').map((x) => +x);
+  const visit = Array.from(new Array(n), () => new Array(m).fill(false));
+
+  const bfs = (start) => {
+    const queue = [start];
+    visit[start[0]][start[1]] = true;
+    let nums = `${map[start[0]][start[1]]}`;
+
+    while (queue.length) {
+      const [r, c] = queue.shift();
+      const info = check.find((item) => item.key === `${r}${c}`);
+      const { exponent } = info;
+      const nowDirection = bitArr[EXPONENT - exponent];
+
+      if (nowDirection === 1) {
+        //가로
+        if (c + 1 < m && !visit[r][c + 1]) {
+          const next = check.find((item) => item.key === `${r}${c + 1}`);
+          const { exponent: nextEx1 } = next;
+          if (nowDirection === bitArr[EXPONENT - nextEx1]) {
+            visit[r][c + 1] = true;
+            queue.push([r, c + 1]);
+            nums += `${map[r][c + 1]}`;
+          }
+        }
+      } else {
+        //세로
+        if (r + 1 < n && !visit[r + 1][c]) {
+          const next = check.find((item) => item.key === `${r + 1}${c}`);
+          const { exponent: nextEx2 } = next;
+          if (nowDirection === bitArr[EXPONENT - nextEx2]) {
+            visit[r + 1][c] = true;
+            queue.push([r + 1, c]);
+            nums += `${map[r + 1][c]}`;
+          }
+        }
+      }
+    }
+    return nums;
+  };
+
+  const result = [];
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < m; j++) {
+      if (!visit[i][j]) {
+        result.push(bfs([i, j]));
+      }
+    }
+  }
+  max = Math.max(
+    max,
+    result.reduce((prev, cur, idx) => {
+      prev += +cur;
+      return prev;
+    }, 0)
+  );
+}
+
+function init() {
+  for (let i = 1; i <= n; i++) {
+    map.push(input[i].split('').map((x) => +x));
+  }
+
+  let count = 0;
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < m; j++) {
+      check.push({
+        key: `${i}${j}`,
+        exponent: count,
+      });
+      count++;
+    }
+  }
+
+  for (let i = 0; i < 1 << (n * m); i++) {
+    let direction = i.toString(2);
+    if (direction.length < n * m) {
+      direction = '0'.repeat(n * m - direction.length) + direction;
+    }
+    createNums(direction);
+  }
+  console.log(max);
+}
+
+init();

--- a/SUPINKIM/BOJ/treetraversal.js
+++ b/SUPINKIM/BOJ/treetraversal.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().split('\n');
+
+const inorder = input[1]
+  .trim()
+  .split(' ')
+  .map((x) => +x);
+const postorder = input[2]
+  .trim()
+  .split(' ')
+  .map((x) => +x);
+
+let result = '';
+
+function travelPostOrder(postStart, postEnd, inStart, inEnd) {
+  const stack = [[postStart, postEnd, inStart, inEnd]];
+  while (stack.length) {
+    const [pStart, pEnd, iStart, iEnd] = stack.pop();
+
+    if (iStart > iEnd || pStart > pEnd) {
+      continue;
+    }
+
+    const rootValue = postorder[pEnd];
+    const rootIndex = inorder.findIndex((node) => node === rootValue);
+    const postIndex = pStart + (rootIndex - iStart);
+    result += rootValue + ' ';
+    stack.push([postIndex, pEnd - 1, rootIndex + 1, iEnd]);
+    stack.push([pStart, postIndex - 1, iStart, rootIndex - 1]);
+  }
+}
+
+function init() {
+  const n = +input[0];
+  travelPostOrder(0, postorder.length - 1, 0, inorder.length - 1);
+}
+
+init();
+
+console.log(result);

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -65,3 +65,5 @@
 - [15652. N과 M(4)(code)](./BOJ/nm4.js) | [문제 보기](https://www.acmicpc.net/problem/15652)
 
 - [2263. 트리 순회(code)](./BOJ/treetraversal.js) | [문제 보기](https://www.acmicpc.net/problem/2263)
+
+- [13913. 숨바꼭질4(code)](./BOJ/hideandshow.js) | [문제 보기](https://www.acmicpc.net/problem/13913)

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -67,3 +67,5 @@
 - [2263. 트리 순회(code)](./BOJ/treetraversal.js) | [문제 보기](https://www.acmicpc.net/problem/2263)
 
 - [13913. 숨바꼭질4(code)](./BOJ/hideandshow.js) | [문제 보기](https://www.acmicpc.net/problem/13913)
+
+- [14391. 종이조각(code)](./BOJ/paper.js) | [문제 보기](https://www.acmicpc.net/problem/14391)

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -62,4 +62,6 @@
 
 - [2146. 다리 만들기(code)](./BOJ/bridge.js) | [문제 보기](https://www.acmicpc.net/problem/2146)
 
-- [2146. N과 M(4)(code)](./BOJ/nm4.js) | [문제 보기](https://www.acmicpc.net/problem/15652)
+- [15652. N과 M(4)(code)](./BOJ/nm4.js) | [문제 보기](https://www.acmicpc.net/problem/15652)
+
+- [2263. 트리 순회(code)](./BOJ/treetraversal.js) | [문제 보기](https://www.acmicpc.net/problem/2263)


### PR DESCRIPTION
[작업내용]
1. 백준 2263. 트리 순회 문제 풀이 추가 
: 중위 순회 결과와 후위 순회 결과를 통해 이진 트리의 전위 순회 결과를 도출하는 문제

* 재귀 및 slice 메소드로 서브 트리를 만들어서 매개변수로 전달하는 방식은 메모리 초과로 테스트 케이스 통과할 수 없음
* stack을 활용한 반복문 및 인덱스를 매개변수로 전달해 while문 종료 조건을 주어 푸는 것으로 변경

2. 백준 13913. 숨바꼭질4 스페셜 저지 문제 풀이 추가
: 3가지 이동 방향에 대해 bfs 탐색

3. 백준 14391. 종이조각 문제 풀이 추가
: bit mask를 활용한 브루트포스 + 탐색 알고리즘 