### PR TITLE
[BOJ] feat : 적록색약 & 최솟값과 최댓값 문제풀이 추가

### DIFF
--- a/SUPINKIM/BOJ/minandmax.js
+++ b/SUPINKIM/BOJ/minandmax.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+const [n, m] = input[0]
+  .trim()
+  .split(' ')
+  .map((x) => +x);
+
+const nums = [0];
+const INT_MAX = 1000000001;
+const INT_MIN = 0;
+
+for (let i = 1; i <= n; i++) {
+  nums.push(+input[i]);
+}
+
+function initMin(tree, node, start, end) {
+  if (start === end) {
+    tree[node].min = nums[start];
+    return tree[node].min;
+  }
+
+  const mid = Math.floor((start + end) / 2);
+  tree[node].min = Math.min(
+    initMin(tree, 2 * node, start, mid),
+    initMin(tree, 2 * node + 1, mid + 1, end)
+  );
+
+  return tree[node].min;
+}
+
+function initMax(tree, node, start, end) {
+  if (start === end) {
+    tree[node].max = nums[start];
+    return tree[node].max;
+  }
+
+  const mid = Math.floor((start + end) / 2);
+  tree[node].max = Math.max(
+    initMax(tree, 2 * node, start, mid),
+    initMax(tree, 2 * node + 1, mid + 1, end)
+  );
+
+  return tree[node].max;
+}
+
+function findMin(tree, node, start, end, left, right) {
+  if (end < left || start > right) {
+    return INT_MAX;
+  }
+  if (left <= start && end <= right) {
+    return tree[node].min;
+  }
+
+  const mid = Math.floor((start + end) / 2);
+  return Math.min(
+    findMin(tree, 2 * node, start, mid, left, right),
+    findMin(tree, 2 * node + 1, mid + 1, end, left, right)
+  );
+}
+
+function findMax(tree, node, start, end, left, right) {
+  if (end < left || start > right) {
+    return INT_MIN;
+  }
+  if (left <= start && end <= right) {
+    return tree[node].max;
+  }
+
+  const mid = Math.floor((start + end) / 2);
+  return Math.max(
+    findMax(tree, 2 * node, start, mid, left, right),
+    findMax(tree, 2 * node + 1, mid + 1, end, left, right)
+  );
+}
+
+function init() {
+  let result = '';
+
+  const height = Math.ceil(Math.log2(n));
+  const treeSize = 1 << (1 + height);
+
+  const tree = Array.from(new Array(treeSize), () => {
+    return {
+      min: Infinity,
+      max: -Infinity,
+    };
+  });
+
+  initMin(tree, 1, 1, n);
+  initMax(tree, 1, 1, n);
+
+  for (let i = n + 1; i <= n + m; i++) {
+    const [left, right] = input[i].split(' ').map((x) => +x);
+    result += `${findMin(tree, 1, 1, n, left, right)} ${findMax(
+      tree,
+      1,
+      1,
+      n,
+      left,
+      right
+    )}\n`;
+  }
+
+  console.log(result.trim());
+}
+
+init();

--- a/SUPINKIM/BOJ/partsum.js
+++ b/SUPINKIM/BOJ/partsum.js
@@ -1,0 +1,83 @@
+const fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+function findSum(tree, node, start, end, left, right) {
+  if (end < left || start > right) return 0;
+
+  if (left <= start && end <= right) {
+    return tree[node];
+  }
+
+  const mid = Math.floor((start + end) / 2);
+  let sum =
+    findSum(tree, 2 * node, start, mid, left, right) +
+    findSum(tree, 2 * node + 1, mid + 1, end, left, right);
+
+  return sum;
+}
+
+function createTree(tree, nums, node, start, end) {
+  if (start === end) {
+    return (tree[node] = nums[start]);
+  }
+
+  const mid = Math.floor((start + end) / 2);
+  tree[node] =
+    createTree(tree, nums, 2 * node, start, mid) +
+    createTree(tree, nums, 2 * node + 1, mid + 1, end);
+
+  return tree[node];
+}
+
+function updateTree(tree, value, index, node, start, end) {
+  if (index < start || index > end) return tree[node];
+
+  if (start === end && start === index) return (tree[node] = value);
+
+  const mid = Math.floor((start + end) / 2);
+  tree[node] =
+    updateTree(tree, value, index, 2 * node, start, mid) +
+    updateTree(tree, value, index, 2 * node + 1, mid + 1, end);
+
+  return tree[node];
+}
+
+function init() {
+  let ans = '';
+  const [n, m, k] = input[0]
+    .trim()
+    .split(' ')
+    .map((x) => +x);
+
+  const nums = [];
+  for (let i = 1; i <= n; i++) {
+    nums.push(+input[i]);
+  }
+
+  const height = Math.ceil(Math.log2(n));
+  const size = 1 << (1 + height);
+
+  const tree = new Array(size).fill(null);
+
+  createTree(tree, nums, 1, 0, nums.length - 1);
+
+  for (let i = n + 1; i <= n + m + k; i++) {
+    const [order, num1, num2] = input[i].split(' ').map((x) => +x);
+
+    switch (order) {
+      case 1:
+        nums[num1 - 1] = num2;
+        updateTree(tree, num2, num1 - 1, 1, 0, nums.length - 1);
+        break;
+      case 2:
+        const result = findSum(tree, 1, 0, nums.length - 1, num1 - 1, num2 - 1);
+        ans += result + '\n';
+        break;
+      default:
+        break;
+    }
+  }
+  console.log(ans.trim());
+}
+
+init();

--- a/SUPINKIM/BOJ/rgb.js
+++ b/SUPINKIM/BOJ/rgb.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().split('\n');
+
+const dx = [-1, 1, 0, 0];
+const dy = [0, 0, -1, 1];
+
+const n = +input[0];
+const map = Array.from(new Array(n), () => new Array());
+let visited = Array.from(new Array(n), () => new Array(n).fill(false));
+
+function checkSameColor(color1, color2) {
+  if (color1 === color2) {
+    return true;
+  }
+  if (color1 === 'R' || color1 === 'G') {
+    if (color2 === 'R' || color2 === 'G') {
+      return true;
+    }
+  }
+  return false;
+}
+
+function checkSameColorReal(color1, color2) {
+  return color1 === color2 ? true : false;
+}
+
+function dfs(start, fn) {
+  const stack = [start];
+
+  while (stack.length) {
+    const [row, col] = stack.pop();
+    visited[row][col] = true;
+
+    const color = map[row][col];
+
+    for (let i = 0; i < dx.length; i++) {
+      if (
+        row + dx[i] < 0 ||
+        row + dx[i] >= n ||
+        col + dy[i] < 0 ||
+        col + dy[i] >= n
+      )
+        continue;
+      if (!visited[row + dx[i]][col + dy[i]]) {
+        if (fn(color, map[row + dx[i]][col + dy[i]])) {
+          stack.push([row + dx[i], col + dy[i]]);
+        }
+      }
+    }
+  }
+}
+
+function init() {
+  for (let i = 1; i <= n; i++) {
+    map[i - 1] = input[i].trim().split('');
+  }
+
+  let result = '';
+  let count = 0;
+
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      if (!visited[i][j]) {
+        dfs([i, j], checkSameColorReal);
+        count++;
+      }
+    }
+  }
+
+  result += `${count} `;
+  count = 0;
+  visited = Array.from(new Array(n), () => new Array(n).fill(false));
+
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      if (!visited[i][j]) {
+        dfs([i, j], checkSameColor);
+        count++;
+      }
+    }
+  }
+
+  result += count;
+
+  console.log(result);
+}
+
+init();

--- a/SUPINKIM/BOJ/sequence.js
+++ b/SUPINKIM/BOJ/sequence.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().split('\n');
+
+const n = +input[0];
+let nums = input[1]
+  .trim()
+  .split(' ')
+  .map((x) => +x);
+
+let dp1 = [];
+dp1[0] = nums[0];
+for (let i = 1; i < nums.length; i++) {
+  dp1[i] = nums[i] + Math.max(dp1[i - 1], 0);
+}
+let max = Math.max(...dp1);
+
+let dp2 = [];
+const reverseNums = nums.reverse();
+dp2[0] = reverseNums[0];
+
+for (let [index, value] of reverseNums.entries()) {
+  if (!index) continue;
+  dp2[index] = reverseNums[index] + Math.max(dp2[index - 1], 0);
+}
+
+const { length } = dp2;
+
+for (let i = 1; i < length - 1; i++) {
+  if (max < dp1[i - 1] + dp2[length - 2 - i]) {
+    max = dp1[i - 1] + dp2[length - 2 - i];
+  }
+}
+
+console.log(max);

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -73,3 +73,7 @@
 - [10026. 적록색약(code)](./BOJ/rgb.js) | [문제 보기](https://www.acmicpc.net/problem/10026)
 
 - [2357. 최댓값과 최솟값(code)](./BOJ/minandmax.js) | [문제 보기](https://www.acmicpc.net/problem/2357)
+
+- [13398. 연속합2(code)](./BOJ/sequence.js) | [문제 보기](https://www.acmicpc.net/problem/13398)
+
+- [2042. 구간 합 구하기(code)](./BOJ/partsum.js) | [문제 보기](https://www.acmicpc.net/problem/2042)

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -69,3 +69,5 @@
 - [13913. 숨바꼭질4(code)](./BOJ/hideandshow.js) | [문제 보기](https://www.acmicpc.net/problem/13913)
 
 - [14391. 종이조각(code)](./BOJ/paper.js) | [문제 보기](https://www.acmicpc.net/problem/14391)
+
+- [10026. 적록색약(code)](./BOJ/rgb.js) | [문제 보기](https://www.acmicpc.net/problem/10026)

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -71,3 +71,5 @@
 - [14391. 종이조각(code)](./BOJ/paper.js) | [문제 보기](https://www.acmicpc.net/problem/14391)
 
 - [10026. 적록색약(code)](./BOJ/rgb.js) | [문제 보기](https://www.acmicpc.net/problem/10026)
+
+- [2357. 최댓값과 최솟값(code)](./BOJ/minandmax.js) | [문제 보기](https://www.acmicpc.net/problem/2357)


### PR DESCRIPTION
[작업 내용]
1. 적록색약 : 간단한 DFS 문제 (조건에 맞는 컴포넌트 개수 구하는 문제)
2. 최솟값과 최댓값 : 세그먼트 트리 문제 풀이 (부모 노드의 값은 좌우 노드, 즉 전체 서브 트리의 범위 내 최댓값 또는 최솟값이 됨)
3. 연속합2 : 기존 연속합(dp)에서 반대쪽에서부터 카운트하는 dp를 하나 더 생성해 각 위치의 원소를 제거했을 때와 
아무 원소도 제거하지 않았을 때 중 더 큰 값을 출력
4. 구간합 : 세그먼트 트리 문제 풀이, 
    중간에 원소의 값이 업데이트 되는 경우에는 createTree가 아닌 updateTree를 호출해 기존 값을 활용해야만 시간 제한 내에 통과 가능