### PR TITLE
[BOJ] feat : 뱀과 사다리 게임 문제 풀이 추가

### DIFF
--- a/SUPINKIM/BOJ/count0.js
+++ b/SUPINKIM/BOJ/count0.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const [n, m] = fs
+  .readFileSync('/dev/stdin')
+  .toString()
+  .trim()
+  .split(' ')
+  .map((x) => +x);
+
+function countFive(num) {
+  let count = 0;
+  while (num) {
+    num = Math.floor(num / 5);
+    count += num;
+  }
+  return count;
+}
+
+function countTwo(num) {
+  let count = 0;
+  while (num) {
+    num = Math.floor(num / 2);
+    count += num;
+  }
+  return count;
+}
+
+function init() {
+  const operand1 = { twoCount: countTwo(n), fiveCount: countFive(n) };
+  const operand2 = { twoCount: countTwo(n - m), fiveCount: countFive(n - m) };
+  const operand3 = { twoCount: countTwo(m), fiveCount: countFive(m) };
+
+  const resultTwo = operand1.twoCount - (operand2.twoCount + operand3.twoCount);
+  const resultFive =
+    operand1.fiveCount - (operand2.fiveCount + operand3.fiveCount);
+
+  return Math.min(resultFive, resultTwo);
+}
+
+console.log(init());

--- a/SUPINKIM/BOJ/operation4.js
+++ b/SUPINKIM/BOJ/operation4.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+let [s, t] = fs
+  .readFileSync('/dev/stdin')
+  .toString()
+  .trim()
+  .split(' ')
+  .map((x) => +x);
+
+const MAX = 1000000000;
+
+function bfs() {
+  const queue = [[s, '']];
+  let index = 0;
+  let visited = [];
+  let success = false;
+  let result = '';
+
+  while (index < queue.length) {
+    let [now, ans] = queue[index];
+
+    if (now === t) {
+      success = true;
+      result = ans;
+      break;
+    }
+
+    for (let i = 0; i < 4; i++) {
+      let temp = now;
+      let operator = '';
+      switch (i) {
+        case 0:
+          temp = now * now;
+          operator = '*';
+          break;
+        case 1:
+          temp = now + now;
+          operator = '+';
+          break;
+        case 2:
+          temp = now - now;
+          operator = '-';
+          break;
+        case 3:
+          if (temp !== 0) {
+            temp = Math.floor(now / now);
+            operator = '/';
+          }
+          break;
+      }
+
+      if (!visited.includes(temp) && temp >= 1 && temp <= MAX) {
+        let str = ans + operator;
+        queue.push([temp, str]);
+        visited.push(temp);
+      }
+    }
+    index++;
+  }
+  return success ? result : -1;
+}
+
+function init() {
+  if (s === t) {
+    console.log(0);
+  } else {
+    const result = bfs();
+    console.log(result);
+  }
+}
+
+init();

--- a/SUPINKIM/BOJ/snakesandladders.js
+++ b/SUPINKIM/BOJ/snakesandladders.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+let input = fs.readFileSync('/dev/stdin').toString().trim().split('\n');
+
+const [n, m] = input[0].split(' ').map((x) => +x);
+const visited = new Array(101).fill(false);
+const adj = new Array(101).fill(0);
+
+function bfs(start) {
+  const queue = [[start, 0]];
+  let index = 0;
+  let min = 0;
+
+  while (index < queue.length) {
+    const [now, count] = queue[index];
+
+    if (now === 100) {
+      min = count;
+      break;
+    }
+
+    for (let i = 1; i <= 6; i++) {
+      if (now + i >= 1 && now + i <= 100 && !visited[now + i]) {
+        visited[now + i] = true;
+        if (adj[now + i] !== 0) {
+          const move = adj[now + i];
+          visited[move] = true;
+          queue.push([move, count + 1]);
+        } else {
+          queue.push([now + i, count + 1]);
+        }
+      }
+    }
+    index++;
+  }
+  return min;
+}
+
+function init() {
+  for (let i = 1; i <= n + m; i++) {
+    const [start, end] = input[i]
+      .trim()
+      .split(' ')
+      .map((x) => +x);
+    adj[start] = end;
+  }
+
+  const result = bfs(1);
+
+  console.log(result);
+}
+
+init();

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -81,3 +81,5 @@
 - [14395. 4연산(code)](./BOJ/operation4.js) | [문제 보기](https://www.acmicpc.net/problem/14395)
 
 - [16928. 뱀과 사다리 게임(code)](./BOJ/snakesandladders.js) | [문제 보기](https://www.acmicpc.net/problem/16928)
+
+- [16928. 조합 0의 개수(code)](./BOJ/count0.js) | [문제 보기](https://www.acmicpc.net/problem/2004)

--- a/SUPINKIM/README.md
+++ b/SUPINKIM/README.md
@@ -77,3 +77,7 @@
 - [13398. 연속합2(code)](./BOJ/sequence.js) | [문제 보기](https://www.acmicpc.net/problem/13398)
 
 - [2042. 구간 합 구하기(code)](./BOJ/partsum.js) | [문제 보기](https://www.acmicpc.net/problem/2042)
+
+- [14395. 4연산(code)](./BOJ/operation4.js) | [문제 보기](https://www.acmicpc.net/problem/14395)
+
+- [16928. 뱀과 사다리 게임(code)](./BOJ/snakesandladders.js) | [문제 보기](https://www.acmicpc.net/problem/16928)


### PR DESCRIPTION
[작업 내용]
1. 백준 (https://www.acmicpc.net/problem/16928) 뱀과 사다리 게임 문제 풀이 추가 
   > bfs로 최단 거리 찾는 문제와 같은 풀이 방법
   > 뱀이나 사다리로 이동 가능한 위치에 도달 시, queue에 해당 값을 넣어주어 100에 최단 거리로 도달하는 주사위 횟수를 리턴
   
2. 백준 4연산 문제 풀이 추가
    > 뱀과 사다리 게임 문제와 동일한 bfs 알고리즘

3. 백준 조합 0의 개수 문제 풀이 추가
    > 처음에 DP로 팩토리얼 계산하려고 했으나 메모리 초과로 실패. 기본적인 2 * 5 의 지수 계산으로 10 개수 도출